### PR TITLE
Incomplete shopping list bug fix

### DIFF
--- a/XIV Helper.xcodeproj/project.pbxproj
+++ b/XIV Helper.xcodeproj/project.pbxproj
@@ -1108,7 +1108,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.1;
+				MARKETING_VERSION = 2.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "hoerr.jared.xiv-helper";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1144,7 +1144,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.1;
+				MARKETING_VERSION = 2.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "hoerr.jared.xiv-helper";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/XIVHelper/Views/ShoppingCart/ShoppingListView.swift
+++ b/XIVHelper/Views/ShoppingCart/ShoppingListView.swift
@@ -45,8 +45,8 @@ struct ShoppingListView: View {
             /// Iterate through ingredients for this recipe.
             for ingredient in userRecipe.recipe.ingredients {
                 /// If the ingredient exists, update its quantity. If not, add this to the list.
-                if var existingIngredient = ingredients.first(where: { $0.id == ingredient.id }) {
-                    existingIngredient.quantity += (recipeQuantity * ingredient.quantity)
+                if let index = ingredients.firstIndex(where: { $0.id == ingredient.id }) {
+                    ingredients[index].quantity += (ingredient.quantity * recipeQuantity)
                 } else {
                     var ingredientToAdd = ingredient
                     ingredientToAdd.quantity = (ingredient.quantity * recipeQuantity)


### PR DESCRIPTION
This PR fixes a bug where shopping lists were not reflecting the correct quantity of ingredients if two or more saved recipes shared an ingredient. Previously, the function used to build the shopping list would not save the updated quantity, but this bug fixes it by writing the updated quantity to the ingredient in its array.

Bumps version number to 2.2.2.